### PR TITLE
Add FastAPI JSON API and React web client

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,10 @@ desired.
 ## Project layout
 
 ```
+├── api
+│   └── app.py            # FastAPI service for browser clients
+├── frontend
+│   └── src/main.jsx      # React client for online play
 ├── classes
 │   ├── classes.py        # Player, Enemy, Mage and supporting data classes
 │   └── items.py          # Simple helpers for consumables
@@ -138,3 +142,40 @@ pytest
 - Prefer dataclasses for new data structures and keep interactions deterministic
   where possible to simplify testing.
 
+
+## Web API and React client
+
+The game engine can now run as a JSON API for browser clients. This makes the
+existing adventure logic usable from a hosted React app while keeping the CLI and
+pygame front-ends intact.
+
+### Start the API
+
+```bash
+pip install -r requirements.txt
+uvicorn api.app:app --reload --host 0.0.0.0 --port 8000
+```
+
+Useful endpoints include:
+
+- `POST /sessions` with `{ "name": "Hero", "player_class": "mage" }` to start a game.
+- `GET /sessions/{session_id}` to reconnect to an in-memory game session.
+- `POST /sessions/{session_id}/move` with `{ "destination": "A1" }` to explore.
+- `POST /sessions/{session_id}/battle/action` to submit battle choices.
+- `POST /sessions/{session_id}/save` and `/load` to use the existing SQLite save slots.
+
+Sessions are in-memory, so a simple single-server deployment is enough for a
+friends-and-family hosted game. For a larger public deployment, back the session
+store with Redis or persist active sessions in SQLite/Postgres before running
+multiple API workers.
+
+### Start the React client
+
+```bash
+cd frontend
+npm install
+VITE_API_BASE_URL=http://localhost:8000 npm run dev
+```
+
+Open the Vite URL, create a session, and share the session id with a friend so
+they can join the same running adventure through the API.

--- a/api/app.py
+++ b/api/app.py
@@ -1,0 +1,281 @@
+"""HTTP API for the text adventure game.
+
+The API keeps the existing :class:`game_logic.core.GameEngine` as the source of
+truth and exposes small JSON endpoints that web clients can call.  Sessions are
+held in memory so multiple browsers can play at the same time; save slots still
+use the existing SQLite persistence layer.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict
+import os
+import secrets
+from typing import Any, Dict, List, Literal, Optional
+
+from fastapi import FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+from pydantic import BaseModel, Field
+
+from classes.classes import Enemy, Mage, Player, Ranger
+from game_logic.core import GameEngine, NodeEvent, startGame
+
+PlayerClass = Literal["player", "mage", "ranger", "cleric"]
+
+
+class StartGameRequest(BaseModel):
+    """Payload used to create a browser-playable game session."""
+
+    name: str = Field(default="Hero", min_length=1, max_length=40)
+    player_class: PlayerClass = "player"
+
+
+class MoveRequest(BaseModel):
+    destination: str = Field(min_length=1, max_length=20)
+
+
+class BattleActionRequest(BaseModel):
+    action: str = Field(default="attack", min_length=1, max_length=20)
+    name: Optional[str] = None
+    target_index: int = 0
+    actor_name: Optional[str] = None
+    target_kind: str = "enemy"
+    target_name: Optional[str] = None
+
+
+class PotionRequest(BaseModel):
+    name: str = Field(min_length=1)
+
+
+class SaveRequest(BaseModel):
+    slot: str = Field(default="slot1", min_length=1, max_length=40)
+
+
+class LoadRequest(BaseModel):
+    slot: str = Field(min_length=1, max_length=40)
+
+
+class GenerateMapRequest(BaseModel):
+    size: Optional[int] = Field(default=None, ge=5, le=40)
+
+
+class PurchaseRequest(BaseModel):
+    item_name: str = Field(min_length=1)
+
+
+_sessions: Dict[str, GameEngine] = {}
+
+app = FastAPI(
+    title="Python Text Adventure API",
+    version="1.0.0",
+    description="JSON API for starting, exploring, fighting, saving, and loading text adventure sessions.",
+)
+cors_origins = [origin.strip() for origin in os.getenv("ADVENTURE_CORS_ORIGINS", "*").split(",")]
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=cors_origins,
+    allow_credentials="*" not in cors_origins,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+
+def _new_session_id() -> str:
+    return secrets.token_urlsafe(12)
+
+
+def _engine_or_404(session_id: str) -> GameEngine:
+    engine = _sessions.get(session_id)
+    if not engine:
+        raise HTTPException(status_code=404, detail="Game session not found")
+    return engine
+
+
+def _item_to_dict(item: Any) -> Dict[str, Any]:
+    if hasattr(item, "to_dict"):
+        return item.to_dict()
+    return dict(item)
+
+
+def _character_to_dict(character: Player) -> Dict[str, Any]:
+    data: Dict[str, Any] = {
+        "name": character.name,
+        "type": character.__class__.__name__,
+        "level": character.level,
+        "hp": character.hp,
+        "max_hp": character.max_hp,
+        "dmg": character.dmg,
+        "exp": character.exp,
+        "gp": character.gp,
+        "is_alive": character.is_alive(),
+        "role": getattr(character, "role", "hero" if not character.is_companion else "companion"),
+    }
+    if isinstance(character, Mage):
+        data.update({"mp": character.mp, "max_mp": character.max_mp})
+    if isinstance(character, Ranger):
+        data.update({"focus": character.focus, "max_focus": character.max_focus})
+    return data
+
+
+def _enemy_to_dict(enemy: Enemy, index: int) -> Dict[str, Any]:
+    return {
+        "index": index,
+        "name": enemy.name,
+        "level": enemy.level,
+        "hp": enemy.hp,
+        "max_hp": enemy.max_hp,
+        "dmg": enemy.dmg,
+        "is_alive": enemy.is_alive(),
+    }
+
+
+def _node_event_to_dict(event: NodeEvent) -> Dict[str, Any]:
+    return asdict(event)
+
+
+def _battle_state(engine: GameEngine) -> Optional[Dict[str, Any]]:
+    if not engine.battle:
+        return None
+    actor = engine.battle.current_actor()
+    return {
+        "current_actor": actor.name if actor else None,
+        "current_actor_type": actor.__class__.__name__ if actor else None,
+        "enemies": [_enemy_to_dict(enemy, idx) for idx, enemy in enumerate(engine.battle.enemies, 1)],
+        "actions": [
+            {"kind": kind, "name": name, "label": kind if name is None else f"{kind} {name}"}
+            for kind, name in engine.list_player_actions()
+        ],
+    }
+
+
+def _state(engine: GameEngine, session_id: str, events: Optional[List[NodeEvent]] = None) -> Dict[str, Any]:
+    map_info = engine.map_blueprints.get(engine.current_map_key)
+    hero = engine.hero
+    return {
+        "session_id": session_id,
+        "map": {
+            "key": engine.current_map_key,
+            "name": map_info.name if map_info else engine.current_map_key,
+            "current_node": engine.current_node,
+            "neighbors": engine.neighbors(),
+        },
+        "party": [_character_to_dict(member) for member in engine.player_party],
+        "hero": _character_to_dict(hero) if hero else None,
+        "inventory": [_item_to_dict(item) for item in hero.sort_inventory()] if hero else [],
+        "potions": [_item_to_dict(item) for item in hero.potions.values()] if hero else [],
+        "shop": [_item_to_dict(item) for item in engine.shop.inventory.values()],
+        "battle": _battle_state(engine),
+        "events": [_node_event_to_dict(event) for event in events or []],
+        "event_log": engine.event_log[-20:],
+        "saves": engine.list_saves(),
+    }
+
+
+def _api_error(exc: Exception) -> HTTPException:
+    if isinstance(exc, KeyError):
+        return HTTPException(status_code=404, detail=str(exc))
+    if isinstance(exc, (RuntimeError, ValueError)):
+        return HTTPException(status_code=400, detail=str(exc))
+    return HTTPException(status_code=500, detail="Unexpected server error")
+
+
+@app.get("/health")
+def health() -> Dict[str, str]:
+    return {"status": "ok"}
+
+
+@app.post("/sessions")
+def start_session(payload: StartGameRequest) -> Dict[str, Any]:
+    session_id = _new_session_id()
+    engine = GameEngine()
+    engine.start_new_game(startGame(payload.name.strip(), payload.player_class))
+    _sessions[session_id] = engine
+    return _state(engine, session_id)
+
+
+@app.get("/sessions/{session_id}")
+def get_session(session_id: str) -> Dict[str, Any]:
+    engine = _engine_or_404(session_id)
+    return _state(engine, session_id)
+
+
+@app.post("/sessions/{session_id}/move")
+def move(session_id: str, payload: MoveRequest) -> Dict[str, Any]:
+    engine = _engine_or_404(session_id)
+    try:
+        events = engine.move_to(payload.destination.upper())
+    except Exception as exc:  # FastAPI converts this to the correct HTTP error below.
+        raise _api_error(exc) from exc
+    return _state(engine, session_id, events)
+
+
+@app.post("/sessions/{session_id}/battle/action")
+def battle_action(session_id: str, payload: BattleActionRequest) -> Dict[str, Any]:
+    engine = _engine_or_404(session_id)
+    try:
+        event = engine.perform_player_action(
+            payload.action,
+            target_index=max(0, payload.target_index - 1),
+            name=payload.name,
+            actor_name=payload.actor_name,
+            target_kind=payload.target_kind,
+            target_name=payload.target_name,
+        )
+    except Exception as exc:
+        raise _api_error(exc) from exc
+    return _state(engine, session_id, [event])
+
+
+@app.post("/sessions/{session_id}/potion")
+def use_potion(session_id: str, payload: PotionRequest) -> Dict[str, Any]:
+    engine = _engine_or_404(session_id)
+    try:
+        engine.player_party[0].use_potion(payload.name)
+        event = NodeEvent("potion", payload=f"Used {payload.name}")
+    except Exception as exc:
+        raise _api_error(exc) from exc
+    return _state(engine, session_id, [event])
+
+
+@app.post("/sessions/{session_id}/shop/purchase")
+def purchase(session_id: str, payload: PurchaseRequest) -> Dict[str, Any]:
+    engine = _engine_or_404(session_id)
+    try:
+        item = engine.purchase_item(payload.item_name)
+        event = NodeEvent("shop", payload=f"Purchased {item.name}")
+    except Exception as exc:
+        raise _api_error(exc) from exc
+    return _state(engine, session_id, [event])
+
+
+@app.post("/sessions/{session_id}/maps/generate")
+def generate_map(session_id: str, payload: GenerateMapRequest) -> Dict[str, Any]:
+    engine = _engine_or_404(session_id)
+    try:
+        event = engine.generate_new_map(size=payload.size)
+    except Exception as exc:
+        raise _api_error(exc) from exc
+    return _state(engine, session_id, [event])
+
+
+@app.post("/sessions/{session_id}/save")
+def save(session_id: str, payload: SaveRequest) -> Dict[str, Any]:
+    engine = _engine_or_404(session_id)
+    try:
+        engine.save_game(payload.slot)
+        event = NodeEvent("save", payload=f"Game saved to '{payload.slot}'.")
+    except Exception as exc:
+        raise _api_error(exc) from exc
+    return _state(engine, session_id, [event])
+
+
+@app.post("/sessions/{session_id}/load")
+def load(session_id: str, payload: LoadRequest) -> Dict[str, Any]:
+    engine = _engine_or_404(session_id)
+    try:
+        engine.load_game(payload.slot)
+        event = NodeEvent("load", payload=f"Loaded save '{payload.slot}'.")
+    except Exception as exc:
+        raise _api_error(exc) from exc
+    return _state(engine, session_id, [event])

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Python Text Adventure</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "python-text-adventure-web",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite --host 0.0.0.0",
+    "build": "vite build",
+    "preview": "vite preview --host 0.0.0.0"
+  },
+  "dependencies": {
+    "vite": "latest",
+    "react": "latest",
+    "react-dom": "latest"
+  },
+  "devDependencies": {}
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,0 +1,235 @@
+import React, { useMemo, useState } from 'react';
+import { createRoot } from 'react-dom/client';
+import './styles.css';
+
+const API_BASE = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8000';
+
+async function api(path, options = {}) {
+  const response = await fetch(`${API_BASE}${path}`, {
+    headers: { 'Content-Type': 'application/json', ...(options.headers || {}) },
+    ...options,
+  });
+  const data = await response.json().catch(() => ({}));
+  if (!response.ok) {
+    throw new Error(data.detail || `Request failed with ${response.status}`);
+  }
+  return data;
+}
+
+function StatBar({ label, value, max, tone = 'hp' }) {
+  const pct = max ? Math.max(0, Math.min(100, Math.round((value / max) * 100))) : 0;
+  return (
+    <div className="statbar">
+      <span>{label}: {value}/{max}</span>
+      <div className="track"><div className={`fill ${tone}`} style={{ width: `${pct}%` }} /></div>
+    </div>
+  );
+}
+
+function EventFeed({ events = [], log = [] }) {
+  const eventLines = events.flatMap((event) => [event.payload, ...(event.details || [])].filter(Boolean));
+  const lines = eventLines.length ? eventLines : log;
+  return (
+    <section className="panel feed">
+      <h2>Adventure Log</h2>
+      <ol>
+        {lines.slice(-12).map((line, index) => <li key={`${line}-${index}`}>{line}</li>)}
+      </ol>
+    </section>
+  );
+}
+
+function App() {
+  const [state, setState] = useState(null);
+  const [name, setName] = useState('Hero');
+  const [playerClass, setPlayerClass] = useState('player');
+  const [sessionInput, setSessionInput] = useState('');
+  const [slot, setSlot] = useState('slot1');
+  const [customAction, setCustomAction] = useState('attack');
+  const [targetIndex, setTargetIndex] = useState(1);
+  const [error, setError] = useState('');
+  const [busy, setBusy] = useState(false);
+
+  const hero = state?.hero;
+  const inBattle = Boolean(state?.battle);
+  const currentActorIsPlayer = state?.battle?.current_actor_type && state.battle.current_actor_type !== 'Enemy';
+  const visibleEvents = useMemo(() => state?.events || [], [state]);
+
+  async function run(work) {
+    setBusy(true);
+    setError('');
+    try {
+      setState(await work());
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  function startGame() {
+    run(() => api('/sessions', {
+      method: 'POST',
+      body: JSON.stringify({ name, player_class: playerClass }),
+    }));
+  }
+
+  function loadSession() {
+    if (!sessionInput.trim()) return;
+    run(() => api(`/sessions/${sessionInput.trim()}`));
+  }
+
+  function move(destination) {
+    run(() => api(`/sessions/${state.session_id}/move`, {
+      method: 'POST',
+      body: JSON.stringify({ destination }),
+    }));
+  }
+
+  function battleAction(action, actionName = null) {
+    run(() => api(`/sessions/${state.session_id}/battle/action`, {
+      method: 'POST',
+      body: JSON.stringify({ action, name: actionName, target_index: Number(targetIndex) || 1 }),
+    }));
+  }
+
+  function usePotion(potionName) {
+    run(() => api(`/sessions/${state.session_id}/potion`, {
+      method: 'POST',
+      body: JSON.stringify({ name: potionName }),
+    }));
+  }
+
+  function saveGame() {
+    run(() => api(`/sessions/${state.session_id}/save`, {
+      method: 'POST',
+      body: JSON.stringify({ slot }),
+    }));
+  }
+
+  function loadGame() {
+    run(() => api(`/sessions/${state.session_id}/load`, {
+      method: 'POST',
+      body: JSON.stringify({ slot }),
+    }));
+  }
+
+  function generateMap() {
+    run(() => api(`/sessions/${state.session_id}/maps/generate`, {
+      method: 'POST',
+      body: JSON.stringify({}),
+    }));
+  }
+
+  if (!state) {
+    return (
+      <main className="shell centered">
+        <section className="hero-card">
+          <p className="eyebrow">Online-ready adventure client</p>
+          <h1>Python Text Adventure</h1>
+          <p>Create a session, share the session id with a friend, and drive the same API-backed adventure from the browser.</p>
+          <div className="form-grid">
+            <label>Hero name<input value={name} onChange={(e) => setName(e.target.value)} /></label>
+            <label>Class
+              <select value={playerClass} onChange={(e) => setPlayerClass(e.target.value)}>
+                <option value="player">Player</option>
+                <option value="mage">Mage</option>
+                <option value="ranger">Ranger</option>
+                <option value="cleric">Cleric</option>
+              </select>
+            </label>
+          </div>
+          <button disabled={busy} onClick={startGame}>Start new adventure</button>
+          <div className="join-row">
+            <input placeholder="Existing session id" value={sessionInput} onChange={(e) => setSessionInput(e.target.value)} />
+            <button disabled={busy} onClick={loadSession}>Join</button>
+          </div>
+          {error && <p className="error">{error}</p>}
+        </section>
+      </main>
+    );
+  }
+
+  return (
+    <main className="shell">
+      <header className="topbar">
+        <div>
+          <p className="eyebrow">Session {state.session_id}</p>
+          <h1>{state.map.name}</h1>
+          <p>Node {state.map.current_node} · Share this session id so friends can connect to the same running game.</p>
+        </div>
+        <button onClick={() => navigator.clipboard?.writeText(state.session_id)}>Copy session id</button>
+      </header>
+
+      {error && <div className="error banner">{error}</div>}
+
+      <div className="grid-layout">
+        <section className="panel">
+          <h2>Party</h2>
+          <div className="party-list">
+            {state.party.map((member) => (
+              <article className="member" key={member.name}>
+                <strong>{member.name}</strong><span>{member.type} · Lv {member.level}</span>
+                <StatBar label="HP" value={member.hp} max={member.max_hp} />
+                {'mp' in member && <StatBar label="MP" value={member.mp} max={member.max_mp} tone="mp" />}
+                {'focus' in member && <StatBar label="Focus" value={member.focus} max={member.max_focus} tone="focus" />}
+              </article>
+            ))}
+          </div>
+        </section>
+
+        <section className="panel action-panel">
+          <h2>{inBattle ? 'Battle' : 'Explore'}</h2>
+          {!inBattle && (
+            <>
+              <p>Choose a neighboring node to travel.</p>
+              <div className="button-row">
+                {state.map.neighbors.map((node) => <button disabled={busy} key={node} onClick={() => move(node)}>Move {node}</button>)}
+              </div>
+              <button className="secondary" disabled={busy} onClick={generateMap}>Discover frontier map</button>
+            </>
+          )}
+          {inBattle && (
+            <>
+              <p>Current turn: <strong>{state.battle.current_actor}</strong></p>
+              <div className="enemy-list">
+                {state.battle.enemies.map((enemy) => (
+                  <button className={targetIndex === enemy.index ? 'target selected' : 'target'} key={enemy.index} onClick={() => setTargetIndex(enemy.index)}>
+                    {enemy.index}. {enemy.name} · {enemy.hp}/{enemy.max_hp} HP
+                  </button>
+                ))}
+              </div>
+              <div className="button-row">
+                {state.battle.actions.map((action, idx) => (
+                  <button disabled={busy || !currentActorIsPlayer} key={`${action.label}-${idx}`} onClick={() => battleAction(action.kind, action.name)}>{action.label}</button>
+                ))}
+              </div>
+              <div className="join-row">
+                <input value={customAction} onChange={(e) => setCustomAction(e.target.value)} placeholder="attack, spell, ability" />
+                <button disabled={busy || !currentActorIsPlayer} onClick={() => battleAction(customAction)}>Send</button>
+              </div>
+            </>
+          )}
+        </section>
+
+        <section className="panel">
+          <h2>Inventory</h2>
+          <p>Gold: <strong>{hero.gp}</strong> · EXP: <strong>{hero.exp}</strong></p>
+          <h3>Potions</h3>
+          <div className="button-row stacked">
+            {state.potions.length ? state.potions.map((potion) => (
+              <button disabled={busy || inBattle} key={potion.name} onClick={() => usePotion(potion.name)}>{potion.name} ×{potion.quantity}</button>
+            )) : <span>No potions</span>}
+          </div>
+          <h3>Save slots</h3>
+          <div className="join-row"><input value={slot} onChange={(e) => setSlot(e.target.value)} /><button onClick={saveGame}>Save</button><button onClick={loadGame}>Load</button></div>
+          <small>Known slots: {state.saves.length ? state.saves.join(', ') : 'none'}</small>
+        </section>
+
+        <EventFeed events={visibleEvents} log={state.event_log} />
+      </div>
+    </main>
+  );
+}
+
+createRoot(document.getElementById('root')).render(<App />);

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1,0 +1,78 @@
+:root {
+  color: #edf4ff;
+  background: #07111f;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+* { box-sizing: border-box; }
+body { margin: 0; min-height: 100vh; background: radial-gradient(circle at top left, #24577a 0, transparent 34rem), #07111f; }
+button, input, select { font: inherit; }
+button {
+  border: 0;
+  border-radius: 999px;
+  padding: 0.75rem 1rem;
+  background: linear-gradient(135deg, #7ce3ff, #9d7cff);
+  color: #08111f;
+  font-weight: 800;
+  cursor: pointer;
+  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.25);
+}
+button:disabled { cursor: not-allowed; filter: grayscale(0.7); opacity: 0.55; }
+button.secondary { background: #14324d; color: #d7ecff; border: 1px solid #2f5d82; }
+input, select {
+  width: 100%;
+  border: 1px solid #31506d;
+  border-radius: 0.9rem;
+  background: #0d1d31;
+  color: #edf4ff;
+  padding: 0.75rem 0.9rem;
+}
+label { display: grid; gap: 0.4rem; color: #b7c9dd; font-weight: 700; }
+
+.shell { width: min(1200px, calc(100% - 2rem)); margin: 0 auto; padding: 2rem 0; }
+.centered { min-height: 100vh; display: grid; place-items: center; }
+.hero-card, .panel, .topbar {
+  border: 1px solid rgba(146, 193, 232, 0.22);
+  border-radius: 1.4rem;
+  background: rgba(9, 22, 38, 0.86);
+  backdrop-filter: blur(14px);
+  box-shadow: 0 24px 70px rgba(0, 0, 0, 0.32);
+}
+.hero-card { max-width: 680px; padding: 2rem; }
+.hero-card h1, .topbar h1 { margin: 0.1rem 0 0.5rem; font-size: clamp(2rem, 6vw, 4.5rem); }
+.eyebrow { color: #7ce3ff; letter-spacing: 0.12em; text-transform: uppercase; font-size: 0.8rem; font-weight: 900; }
+.form-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 1rem; margin: 1.5rem 0; }
+.join-row { display: flex; gap: 0.75rem; margin-top: 1rem; }
+.join-row input { min-width: 0; }
+
+.topbar { margin-bottom: 1rem; padding: 1.5rem; display: flex; justify-content: space-between; gap: 1rem; align-items: center; }
+.grid-layout { display: grid; grid-template-columns: 1fr 1.4fr 1fr; gap: 1rem; align-items: start; }
+.panel { padding: 1.2rem; }
+.panel h2 { margin-top: 0; }
+.feed { grid-column: 1 / -1; }
+.feed ol { margin: 0; padding-left: 1.25rem; display: grid; gap: 0.5rem; color: #d7e6f5; }
+.party-list, .enemy-list, .button-row { display: grid; gap: 0.75rem; }
+.button-row { grid-template-columns: repeat(auto-fit, minmax(120px, 1fr)); }
+.button-row.stacked { grid-template-columns: 1fr; }
+.member, .target {
+  padding: 0.85rem;
+  border: 1px solid #24405d;
+  border-radius: 1rem;
+  background: #0b1a2c;
+}
+.member { display: grid; gap: 0.55rem; }
+.member span { color: #a7bdd3; }
+.target { text-align: left; color: #edf4ff; background: #0d1d31; box-shadow: none; }
+.target.selected { border-color: #7ce3ff; outline: 2px solid rgba(124, 227, 255, 0.2); }
+.statbar { display: grid; gap: 0.35rem; color: #b8cce1; font-size: 0.9rem; }
+.track { height: 0.55rem; background: #152a41; border-radius: 999px; overflow: hidden; }
+.fill { height: 100%; border-radius: inherit; background: #72f2a4; }
+.fill.mp { background: #80b7ff; }
+.fill.focus { background: #ffd36f; }
+.error { color: #ffd2d2; background: rgba(146, 33, 33, 0.28); border: 1px solid rgba(255, 128, 128, 0.35); padding: 0.75rem; border-radius: 0.8rem; }
+.banner { margin-bottom: 1rem; }
+
+@media (max-width: 900px) {
+  .grid-layout, .form-grid { grid-template-columns: 1fr; }
+  .topbar, .join-row { flex-direction: column; align-items: stretch; }
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+fastapi>=0.110
+uvicorn[standard]>=0.27
+pygame>=2.5

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,33 @@
+import pytest
+
+fastapi = pytest.importorskip("fastapi")
+from fastapi.testclient import TestClient
+
+from api.app import app, _sessions
+
+
+def test_api_starts_session_and_returns_playable_state():
+    _sessions.clear()
+    client = TestClient(app)
+
+    response = client.post("/sessions", json={"name": "WebHero", "player_class": "mage"})
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["session_id"]
+    assert data["hero"]["name"] == "WebHero"
+    assert data["hero"]["type"] == "Mage"
+    assert data["map"]["current_node"] == "A0"
+    assert data["map"]["neighbors"]
+    assert data["battle"] is None
+
+
+def test_api_rejects_invalid_move_with_400():
+    _sessions.clear()
+    client = TestClient(app)
+    session = client.post("/sessions", json={"name": "WebHero", "player_class": "player"}).json()
+
+    response = client.post(f"/sessions/{session['session_id']}/move", json={"destination": "NOPE"})
+
+    assert response.status_code == 400
+    assert "Cannot move" in response.json()["detail"]


### PR DESCRIPTION
### Motivation
- Expose the existing `GameEngine` to a networked clients so sessions can be played from a browser and shared with friends.  
- Provide a lightweight, hosted-friendly web UI that reuses the core game logic without changing the CLI or pygame front-ends.  
- Keep the engine stateless with respect to input handling so the API can drive play and multiple front-ends can consume the same events.  

### Description
- Added a FastAPI service at `api/app.py` exposing session lifecycle, movement, battle actions, potion use, shop purchases, map generation, and save/load endpoints with in-memory session storage and CORS support.  
- Added a Vite + React client under `frontend/` (`src/main.jsx`, `styles.css`, `index.html`, `package.json`) that can start/join sessions, show party and battle state, perform moves and battle actions, and call save/load endpoints.  
- Added `requirements.txt`, `tests/test_api.py` (API smoke tests using `fastapi.testclient` guarded with `pytest.importorskip`), and updated `README.md` to document API and frontend usage.  
- Included small serialization and view helpers in the API to convert engine objects to JSON (`_character_to_dict`, `_battle_state`, `_state`) and a lightweight error mapping function (`_api_error`).  

### Testing
- Ran the full test-suite with `pytest`, which completed successfully: `25 passed, 1 skipped`.  
- Compiled new modules with `python -m compileall api game_logic classes` which succeeded.  
- Attempted to install runtime dependencies for the API and frontend; `pip install fastapi uvicorn` and `npm install` were blocked by the environment package registry/proxy (HTTP 403), so an end-to-end FastAPI runtime and local frontend build were not executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc0c1416a08328a23fa17d3b45ae89)