### PR TITLE
Add web API and React client

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,29 @@ Additional world commands include:
   random value).
 - `saves` – list the available save slots.
 
+
+### Browser/API mode
+
+```bash
+python main.py --mode web --host 0.0.0.0 --port 8000
+```
+
+This starts a dependency-free HTTP server that exposes a JSON API and serves the
+React browser client from `frontend/static`. Open `http://localhost:8000`, create
+a character, and share the generated `?session=<id>` link with friends so they
+can interact with the same in-memory adventure session. The API is intentionally
+small and host-friendly:
+
+- `POST /api/session` creates a game session with `{ "name": "Hero", "class": "mage" }`.
+- `GET /api/session?id=<session_id>` returns the latest state for a shared game.
+- `POST /api/move` moves to a neighboring node.
+- `POST /api/battle/action` performs `attack`, `spell`, `ability`, or `potion` actions.
+- `POST /api/shop/buy`, `POST /api/save`, `POST /api/load`, and `POST /api/generate` cover shop, persistence, and frontier-map actions.
+
+Active web sessions are stored in memory, while save slots still use the same
+SQLite database as text and pygame modes. For production hosting, run one server
+process behind HTTPS and set `ADVENTURE_DB` to a durable path.
+
 ### Pygame mode
 
 ```bash
@@ -117,6 +140,10 @@ desired.
 │   ├── beginner_map.py   # Introductory map
 │   ├── intermediate_map.py  # Mid-game routes
 │   └── advanced_map.py   # Frontier Bastion layout
+├── api
+│   └── server.py         # JSON API and static React host
+├── frontend
+│   └── static            # Browser client served by the API
 ├── ui
 │   └── pygame_ui.py      # Graphical front-end
 └── tests                 # Pytest suite

--- a/api/server.py
+++ b/api/server.py
@@ -1,0 +1,290 @@
+"""Small HTTP API and static React host for the adventure game.
+
+This module intentionally uses only Python's standard library so the game can be
+served on a small VM, Replit, Codespace, or a friend's laptop without adding a
+framework requirement.  It exposes JSON endpoints consumed by the React app in
+``frontend/static`` and keeps active games in memory, keyed by a shareable
+session id.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import mimetypes
+import os
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from threading import RLock
+from typing import Any, Dict, List, Optional
+from urllib.parse import parse_qs, urlparse
+from uuid import uuid4
+
+from classes.classes import Enemy, Mage, Player
+from game_logic.core import GameEngine, NodeEvent, startGame
+
+ROOT = Path(__file__).resolve().parents[1]
+STATIC_DIR = ROOT / "frontend" / "static"
+
+
+def _item_summary(item: Any) -> Dict[str, Any]:
+    return {
+        "name": item.name,
+        "level": item.level,
+        "slot": item.slot,
+        "dmg": item.dmg,
+        "hp": item.hp,
+        "mp": item.mp,
+        "value": item.value,
+        "quantity": item.quantity,
+    }
+
+
+def _player_summary(player: Player) -> Dict[str, Any]:
+    data: Dict[str, Any] = {
+        "name": player.name,
+        "class": player.__class__.__name__,
+        "level": player.level,
+        "hp": player.hp,
+        "max_hp": player.max_hp,
+        "dmg": player.dmg,
+        "exp": player.exp,
+        "gp": player.gp,
+        "alive": player.is_alive(),
+        "potions": [_item_summary(item) for item in player.potions.values()],
+        "inventory": [_item_summary(item) for item in player.inventory.values()],
+        "equipment": {slot: _item_summary(item) for slot, item in player.equipment.items()},
+    }
+    if isinstance(player, Mage):
+        data["mp"] = player.mp
+        data["max_mp"] = player.max_mp
+        data["spells"] = [spell.to_dict() for spell in player.available_spells()]
+    if hasattr(player, "available_abilities"):
+        data["abilities"] = list(player.available_abilities())  # type: ignore[attr-defined]
+    if hasattr(player, "focus"):
+        data["focus"] = getattr(player, "focus")
+        data["max_focus"] = getattr(player, "max_focus")
+    role = getattr(player, "role", None)
+    if role:
+        data["role"] = role
+    return data
+
+
+def _enemy_summary(enemy: Enemy, index: int) -> Dict[str, Any]:
+    return {
+        "index": index,
+        "name": enemy.name,
+        "level": enemy.level,
+        "hp": enemy.hp,
+        "max_hp": enemy.max_hp,
+        "dmg": enemy.dmg,
+        "alive": enemy.is_alive(),
+    }
+
+
+def _node_event_summary(event: NodeEvent) -> Dict[str, Any]:
+    return {
+        "kind": event.kind,
+        "payload": event.payload,
+        "details": list(event.details),
+        "game_over": event.game_over,
+    }
+
+
+class SessionStore:
+    """Thread-safe in-memory game session registry."""
+
+    def __init__(self) -> None:
+        self._sessions: Dict[str, GameEngine] = {}
+        self._lock = RLock()
+
+    def create(self, name: str, player_class: str) -> str:
+        engine = GameEngine()
+        engine.start_new_game(startGame(name or "Hero", player_class or "player"))
+        session_id = uuid4().hex[:10]
+        with self._lock:
+            self._sessions[session_id] = engine
+        return session_id
+
+    def get(self, session_id: str) -> GameEngine:
+        with self._lock:
+            engine = self._sessions.get(session_id)
+        if not engine:
+            raise KeyError(f"Session '{session_id}' was not found")
+        return engine
+
+    def delete(self, session_id: str) -> None:
+        with self._lock:
+            self._sessions.pop(session_id, None)
+
+
+STORE = SessionStore()
+
+
+def describe_engine(engine: GameEngine, session_id: str, events: Optional[List[NodeEvent]] = None) -> Dict[str, Any]:
+    """Return a JSON-serializable snapshot for clients."""
+
+    battle = engine.battle
+    map_info = engine.map_blueprints.get(engine.current_map_key)
+    actor = battle.current_actor() if battle else None
+    state: Dict[str, Any] = {
+        "session_id": session_id,
+        "current_map": {
+            "key": engine.current_map_key,
+            "name": map_info.name if map_info else engine.current_map_key,
+        },
+        "current_node": engine.current_node,
+        "neighbors": engine.neighbors() if not battle else [],
+        "in_battle": engine.in_battle(),
+        "party": [_player_summary(member) for member in engine.player_party],
+        "event_log": engine.event_log[-20:],
+        "events": [_node_event_summary(event) for event in events or []],
+        "saves": engine.list_saves(),
+    }
+    if battle:
+        state["battle"] = {
+            "current_actor": actor.name if actor else None,
+            "current_actor_type": "player" if isinstance(actor, Player) else "enemy" if actor else None,
+            "enemies": [_enemy_summary(enemy, idx) for idx, enemy in enumerate(battle.enemies, 1)],
+            "actions": [
+                {"kind": kind, "name": name, "label": kind if not name else f"{kind} {name}"}
+                for kind, name in engine.list_player_actions()
+            ],
+        }
+    else:
+        state["shop"] = [_item_summary(item) for item in engine.shop.list_items()]
+    return state
+
+
+class AdventureHandler(BaseHTTPRequestHandler):
+    server_version = "AdventureAPI/1.0"
+
+    def _json(self, payload: Dict[str, Any], status: HTTPStatus = HTTPStatus.OK) -> None:
+        body = json.dumps(payload).encode("utf-8")
+        self.send_response(status.value)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.send_header("Access-Control-Allow-Origin", "*")
+        self.send_header("Access-Control-Allow-Headers", "Content-Type")
+        self.send_header("Access-Control-Allow-Methods", "GET,POST,OPTIONS")
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _read_json(self) -> Dict[str, Any]:
+        length = int(self.headers.get("Content-Length", "0") or "0")
+        if length <= 0:
+            return {}
+        raw = self.rfile.read(length).decode("utf-8")
+        return json.loads(raw or "{}")
+
+    def _send_static(self, path: str) -> None:
+        relative = path.lstrip("/") or "index.html"
+        if relative.startswith("api/"):
+            self._json({"error": "Not found"}, HTTPStatus.NOT_FOUND)
+            return
+        file_path = (STATIC_DIR / relative).resolve()
+        if not str(file_path).startswith(str(STATIC_DIR.resolve())) or not file_path.is_file():
+            file_path = STATIC_DIR / "index.html"
+        content = file_path.read_bytes()
+        mime = mimetypes.guess_type(str(file_path))[0] or "application/octet-stream"
+        self.send_response(HTTPStatus.OK.value)
+        self.send_header("Content-Type", mime)
+        self.send_header("Content-Length", str(len(content)))
+        self.end_headers()
+        self.wfile.write(content)
+
+    def do_OPTIONS(self) -> None:  # noqa: N802 - stdlib hook
+        self._json({})
+
+    def do_GET(self) -> None:  # noqa: N802 - stdlib hook
+        parsed = urlparse(self.path)
+        if parsed.path == "/api/health":
+            self._json({"ok": True})
+            return
+        if parsed.path == "/api/session":
+            query = parse_qs(parsed.query)
+            session_id = query.get("id", [""])[0]
+            try:
+                engine = STORE.get(session_id)
+                self._json(describe_engine(engine, session_id))
+            except KeyError as exc:
+                self._json({"error": str(exc)}, HTTPStatus.NOT_FOUND)
+            return
+        self._send_static(parsed.path)
+
+    def do_POST(self) -> None:  # noqa: N802 - stdlib hook
+        parsed = urlparse(self.path)
+        try:
+            if parsed.path == "/api/session":
+                data = self._read_json()
+                session_id = STORE.create(str(data.get("name", "Hero")), str(data.get("class", "player")))
+                self._json(describe_engine(STORE.get(session_id), session_id), HTTPStatus.CREATED)
+                return
+
+            data = self._read_json()
+            session_id = str(data.get("session_id", ""))
+            engine = STORE.get(session_id)
+            if parsed.path == "/api/move":
+                destination = str(data.get("node", "")).upper()
+                events = engine.move_to(destination)
+                self._json(describe_engine(engine, session_id, events))
+                return
+            if parsed.path == "/api/battle/action":
+                event = engine.perform_player_action(
+                    str(data.get("action", "attack")),
+                    target_index=max(0, int(data.get("target_index", 0))),
+                    name=data.get("name"),
+                    actor_name=data.get("actor_name"),
+                    target_kind=str(data.get("target_kind", "enemy")),
+                    target_name=data.get("target_name"),
+                )
+                self._json(describe_engine(engine, session_id, [event]))
+                return
+            if parsed.path == "/api/shop/buy":
+                item = engine.purchase_item(str(data.get("item", "")))
+                event = NodeEvent("shop", payload=f"Purchased {item.name}")
+                self._json(describe_engine(engine, session_id, [event]))
+                return
+            if parsed.path == "/api/save":
+                slot = str(data.get("slot", "web")) or "web"
+                engine.save_game(slot)
+                event = NodeEvent("save", payload=f"Saved to {slot}")
+                self._json(describe_engine(engine, session_id, [event]))
+                return
+            if parsed.path == "/api/load":
+                slot = str(data.get("slot", ""))
+                engine.load_game(slot)
+                event = NodeEvent("load", payload=f"Loaded {slot}")
+                self._json(describe_engine(engine, session_id, [event]))
+                return
+            if parsed.path == "/api/generate":
+                size = data.get("size")
+                event = engine.generate_new_map(size=int(size) if size else None)
+                self._json(describe_engine(engine, session_id, [event]))
+                return
+            self._json({"error": "Not found"}, HTTPStatus.NOT_FOUND)
+        except (KeyError, ValueError, RuntimeError, json.JSONDecodeError) as exc:
+            self._json({"error": str(exc)}, HTTPStatus.BAD_REQUEST)
+
+    def log_message(self, format: str, *args: Any) -> None:
+        if os.environ.get("ADVENTURE_API_LOGS"):
+            super().log_message(format, *args)
+
+
+def run(host: str = "0.0.0.0", port: int = 8000) -> None:
+    server = ThreadingHTTPServer((host, port), AdventureHandler)
+    print(f"Serving adventure API and React client on http://{host}:{port}")
+    server.serve_forever()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Serve the adventure game API and React front end")
+    parser.add_argument("--host", default=os.environ.get("HOST", "0.0.0.0"))
+    parser.add_argument("--port", type=int, default=int(os.environ.get("PORT", "8000")))
+    args = parser.parse_args()
+    run(args.host, args.port)
+
+
+if __name__ == "__main__":
+    main()

--- a/frontend/static/app.jsx
+++ b/frontend/static/app.jsx
@@ -1,0 +1,121 @@
+const { useEffect, useMemo, useState } = React;
+
+const api = async (path, body) => {
+  const options = body
+    ? { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(body) }
+    : {};
+  const response = await fetch(path, options);
+  const payload = await response.json();
+  if (!response.ok) throw new Error(payload.error || "Request failed");
+  return payload;
+};
+
+function HealthBar({ value, max }) {
+  const percent = Math.max(0, Math.min(100, Math.round((value / Math.max(1, max)) * 100)));
+  return <div className="hpbar"><span style={{ width: `${percent}%` }} /></div>;
+}
+
+function StartScreen({ onStart, error }) {
+  const [name, setName] = useState("Hero");
+  const [klass, setKlass] = useState("player");
+  const [joinId, setJoinId] = useState(new URLSearchParams(location.search).get("session") || "");
+  return (
+    <section className="card login stack">
+      <span className="badge">Online API prototype</span>
+      <h2>Start or join an adventure</h2>
+      <p className="muted">Create a hosted session, send the share link to friends, and everyone can push the same party forward from a browser.</p>
+      {error && <div className="error">{error}</div>}
+      <label className="stack">Hero name<input value={name} onChange={(event) => setName(event.target.value)} /></label>
+      <label className="stack">Class<select value={klass} onChange={(event) => setKlass(event.target.value)}>
+        <option value="player">Player</option>
+        <option value="mage">Mage</option>
+        <option value="ranger">Ranger</option>
+        <option value="cleric">Cleric</option>
+      </select></label>
+      <div className="row"><button onClick={() => onStart({ name, class: klass })}>Create session</button></div>
+      <label className="stack">Join session id<input placeholder="Paste a session id" value={joinId} onChange={(event) => setJoinId(event.target.value)} /></label>
+      <button className="secondary" disabled={!joinId.trim()} onClick={() => onStart(null, joinId.trim())}>Join shared game</button>
+    </section>
+  );
+}
+
+function PartyPanel({ party }) {
+  return <section className="card"><h3 className="panel-title">Party</h3><div className="stat-list">
+    {party.map((member) => <article className="stat-card" key={member.name}>
+      <strong>{member.name}</strong> <span className="muted">{member.class}{member.role ? ` · ${member.role}` : ""}</span>
+      <div className="muted">Lv {member.level} · {member.gp} gp · {member.dmg} dmg</div>
+      <div>{member.hp}/{member.max_hp} HP {member.max_mp ? `· ${member.mp}/${member.max_mp} MP` : ""}</div>
+      <HealthBar value={member.hp} max={member.max_hp} />
+    </article>)}
+  </div></section>;
+}
+
+function BattlePanel({ state, send }) {
+  const battle = state.battle;
+  const [target, setTarget] = useState(0);
+  const actions = battle?.actions?.length ? battle.actions : [{ kind: "attack", name: null, label: "attack" }];
+  return <section className="card stack">
+    <h3 className="panel-title">Battle</h3>
+    <p><span className="badge">Turn</span> {battle.current_actor || "Waiting"}</p>
+    <div className="stat-list">
+      {battle.enemies.map((enemy, index) => <button className="stat-card enemy" key={enemy.name} onClick={() => setTarget(index)} style={{ textAlign: "left", outline: target === index ? "2px solid #79ffe1" : "none" }}>
+        <strong>{enemy.index}. {enemy.name}</strong> <span className="muted">Lv {enemy.level}</span>
+        <div>{enemy.hp}/{enemy.max_hp} HP</div><HealthBar value={enemy.hp} max={enemy.max_hp} />
+      </button>)}
+    </div>
+    <div className="actions">
+      {actions.map((action) => <button key={`${action.kind}-${action.name || "basic"}`} disabled={battle.current_actor_type !== "player"} onClick={() => send("/api/battle/action", { action: action.kind, name: action.name, target_index: target })}>{action.label}</button>)}
+    </div>
+  </section>;
+}
+
+function WorldPanel({ state, send }) {
+  const [slot, setSlot] = useState("web");
+  return <section className="card stack">
+    <div><span className="badge">{state.current_map.name}</span><div className="map-node">{state.current_node}</div></div>
+    <p className="muted">Choose a neighboring node to move. Shops, fishing spots, allies, portals, and battles are handled by the API.</p>
+    <div className="actions">{state.neighbors.map((node) => <button key={node} onClick={() => send("/api/move", { node })}>Move {node}</button>)}</div>
+    <div className="row"><button className="secondary" onClick={() => send("/api/generate", {})}>Discover frontier map</button></div>
+    <h3 className="panel-title">Shop</h3>
+    <div className="actions">{(state.shop || []).slice(0, 6).map((item) => <button className="secondary" key={item.name} onClick={() => send("/api/shop/buy", { item: item.name })}>{item.name} · {item.value}gp</button>)}</div>
+    <div className="row"><input style={{ maxWidth: 180 }} value={slot} onChange={(event) => setSlot(event.target.value)} /><button className="secondary" onClick={() => send("/api/save", { slot })}>Save</button><button className="secondary" onClick={() => send("/api/load", { slot })}>Load</button></div>
+  </section>;
+}
+
+function EventLog({ state }) {
+  const recentEvents = useMemo(() => (state.events || []).flatMap((event) => [event.payload, ...(event.details || [])].filter(Boolean)), [state]);
+  return <section className="card log"><h3 className="panel-title">Adventure log</h3>
+    {[...recentEvents, ...(state.event_log || []).slice().reverse()].slice(0, 28).map((line, index) => <div className="event" key={`${line}-${index}`}>{line}</div>)}
+  </section>;
+}
+
+function Game() {
+  const [state, setState] = useState(null);
+  const [error, setError] = useState("");
+  const start = async (character, joinId) => {
+    try {
+      setError("");
+      const next = joinId ? await api(`/api/session?id=${encodeURIComponent(joinId)}`) : await api("/api/session", character);
+      history.replaceState(null, "", `?session=${next.session_id}`);
+      setState(next);
+    } catch (err) { setError(err.message); }
+  };
+  const send = async (path, body) => {
+    try { setError(""); setState(await api(path, { session_id: state.session_id, ...body })); }
+    catch (err) { setError(err.message); }
+  };
+  useEffect(() => {
+    const session = new URLSearchParams(location.search).get("session");
+    if (session) start(null, session);
+  }, []);
+  return <div className="app-shell">
+    <header className="hero"><h1>Python Text Adventure</h1><p>Now playable through a tiny JSON API with a React front end. Host it, share the session id, and let friends collaborate on the same run.</p></header>
+    {!state ? <StartScreen onStart={start} error={error} /> : <>
+      {error && <div className="error">{error}</div>}
+      <p className="muted">Share: <span className="share">{location.origin + location.pathname + `?session=${state.session_id}`}</span></p>
+      <div className="grid"><div className="stack">{state.in_battle ? <BattlePanel state={state} send={send} /> : <WorldPanel state={state} send={send} />}<EventLog state={state} /></div><PartyPanel party={state.party} /></div>
+    </>}
+  </div>;
+}
+
+ReactDOM.createRoot(document.getElementById("root")).render(<Game />);

--- a/frontend/static/index.html
+++ b/frontend/static/index.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Python Text Adventure Online</title>
+    <link rel="stylesheet" href="/styles.css" />
+    <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
+    <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+    <script crossorigin src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+  </head>
+  <body>
+    <main id="root"></main>
+    <script type="text/babel" src="/app.jsx"></script>
+  </body>
+</html>

--- a/frontend/static/styles.css
+++ b/frontend/static/styles.css
@@ -1,0 +1,66 @@
+:root {
+  color-scheme: dark;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: #090f1d;
+  color: #edf2ff;
+}
+
+* { box-sizing: border-box; }
+body { margin: 0; min-height: 100vh; background: radial-gradient(circle at top left, #263e73, #090f1d 45%); }
+button, input, select { font: inherit; }
+button {
+  border: 0;
+  border-radius: 999px;
+  background: #79ffe1;
+  color: #06121f;
+  cursor: pointer;
+  font-weight: 800;
+  padding: 0.75rem 1rem;
+  transition: transform 120ms ease, opacity 120ms ease;
+}
+button:hover { transform: translateY(-1px); }
+button:disabled { cursor: not-allowed; opacity: 0.45; transform: none; }
+input, select {
+  width: 100%;
+  border: 1px solid #42557e;
+  border-radius: 0.75rem;
+  background: rgba(6, 14, 29, 0.78);
+  color: #edf2ff;
+  padding: 0.7rem 0.8rem;
+}
+
+.app-shell { max-width: 1180px; margin: 0 auto; padding: 2rem; }
+.hero { display: grid; gap: 1rem; margin-bottom: 1.5rem; }
+.hero h1 { font-size: clamp(2.25rem, 6vw, 5rem); line-height: 0.95; margin: 0; }
+.hero p { color: #b9c6e9; margin: 0; max-width: 760px; }
+.card {
+  background: rgba(10, 19, 38, 0.78);
+  border: 1px solid rgba(158, 180, 255, 0.18);
+  border-radius: 1.25rem;
+  box-shadow: 0 24px 70px rgba(0, 0, 0, 0.32);
+  padding: 1rem;
+}
+.grid { display: grid; grid-template-columns: minmax(0, 1.6fr) minmax(320px, 0.9fr); gap: 1rem; align-items: start; }
+.row { display: flex; flex-wrap: wrap; gap: 0.75rem; align-items: center; }
+.stack { display: grid; gap: 0.8rem; }
+.login { max-width: 560px; }
+.badge { display: inline-flex; align-items: center; border-radius: 999px; background: rgba(121, 255, 225, 0.14); color: #9fffe8; padding: 0.25rem 0.7rem; font-size: 0.85rem; font-weight: 800; }
+.panel-title { margin: 0 0 0.75rem; color: #dfe7ff; }
+.map-node { font-size: 2rem; font-weight: 900; }
+.muted { color: #9fb0dc; }
+.error { background: rgba(255, 91, 129, 0.15); border: 1px solid rgba(255, 91, 129, 0.5); color: #ffd1dc; padding: 0.75rem; border-radius: 0.8rem; }
+.event { border-left: 3px solid #79ffe1; padding: 0.45rem 0.75rem; background: rgba(255,255,255,0.04); border-radius: 0.4rem; }
+.stat-list { display: grid; gap: 0.65rem; }
+.stat-card { background: rgba(255,255,255,0.045); border-radius: 0.9rem; padding: 0.75rem; }
+.hpbar { height: 0.65rem; border-radius: 99px; overflow: hidden; background: #18233b; margin-top: 0.45rem; }
+.hpbar > span { display: block; height: 100%; background: linear-gradient(90deg, #79ffe1, #93ff75); }
+.enemy .hpbar > span { background: linear-gradient(90deg, #ff5b81, #ffc857); }
+.actions { display: flex; flex-wrap: wrap; gap: 0.6rem; }
+.actions button.secondary { background: #263e73; color: #edf2ff; }
+.log { max-height: 340px; overflow: auto; }
+.share { user-select: all; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; background: rgba(255,255,255,0.08); padding: 0.35rem 0.55rem; border-radius: 0.5rem; }
+
+@media (max-width: 840px) {
+  .app-shell { padding: 1rem; }
+  .grid { grid-template-columns: 1fr; }
+}

--- a/main.py
+++ b/main.py
@@ -338,12 +338,18 @@ def run_text_mode() -> None:
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Python Text Adventure")
-    parser.add_argument("--mode", choices=["text", "pygame"], default="text")
+    parser.add_argument("--mode", choices=["text", "pygame", "web"], default="text")
+    parser.add_argument("--host", default="0.0.0.0", help="Host for --mode web")
+    parser.add_argument("--port", type=int, default=8000, help="Port for --mode web")
     args = parser.parse_args()
     if args.mode == "pygame":
         from ui.pygame_ui import run_pygame_ui
 
         run_pygame_ui()
+    elif args.mode == "web":
+        from api.server import run as run_web_server
+
+        run_web_server(args.host, args.port)
     else:
         run_text_mode()
 

--- a/tests/test_api_server.py
+++ b/tests/test_api_server.py
@@ -1,0 +1,29 @@
+from api.server import SessionStore, describe_engine
+
+
+def test_create_session_returns_shareable_state(monkeypatch, tmp_path):
+    monkeypatch.setenv("ADVENTURE_DB", str(tmp_path / "api_game.db"))
+    store = SessionStore()
+    session_id = store.create("WebHero", "mage")
+    state = describe_engine(store.get(session_id), session_id)
+
+    assert state["session_id"] == session_id
+    assert state["current_node"] == "A0"
+    assert state["neighbors"]
+    assert state["party"][0]["name"] == "WebHero"
+    assert state["party"][0]["class"] == "Mage"
+
+
+def test_describe_engine_reports_events_after_move(monkeypatch, tmp_path):
+    monkeypatch.setenv("ADVENTURE_DB", str(tmp_path / "api_game.db"))
+    store = SessionStore()
+    session_id = store.create("Walker", "player")
+    engine = store.get(session_id)
+    destination = engine.neighbors()[0]
+
+    events = engine.move_to(destination)
+    state = describe_engine(engine, session_id, events)
+
+    assert state["current_node"] == destination
+    assert "events" in state
+    assert state["in_battle"] is engine.in_battle()


### PR DESCRIPTION
### Motivation

- Make the game playable online and shareable so friends can interact with the same run via a browser.
- Provide a lightweight, dependency-free server so the project can be hosted on simple platforms (Replit, Codespaces, a VM) without adding a web-framework dependency.
- Expose the existing `GameEngine` as an API surface so multiple front-ends can drive the same core logic.

### Description

- Added a small HTTP API server at `api/server.py` that uses `ThreadingHTTPServer` and provides JSON endpoints for session creation/lookup, movement, battle actions, shop buy, save/load, and frontier map generation (endpoints: `POST /api/session`, `GET /api/session?id=...`, `POST /api/move`, `POST /api/battle/action`, `POST /api/shop/buy`, `POST /api/save`, `POST /api/load`, `POST /api/generate`).
- Implemented `SessionStore` (in-memory, thread-safe) and `describe_engine` to return serializable snapshots consumed by clients; included a safe static-file handler to serve the browser app from `frontend/static`.
- Added a minimal React browser client in `frontend/static` (`index.html`, `app.jsx`, `styles.css`) that can create/join sessions, move nodes, perform battle actions, buy items, save/load, generate frontier maps and share a `?session=<id>` URL.
- Wire up CLI: `main.py` now accepts `--mode web` plus `--host`/`--port` and will host the API and static client; also updated README and project layout to document usage and endpoints.
- Added tests in `tests/test_api_server.py` that exercise session creation and state snapshots returned by `describe_engine`.

### Testing

- Ran the full test-suite with `pytest -q` and all tests passed (`27 passed`).
- Verified code compiles with `python -m py_compile api/server.py main.py` which succeeded.
- Started the server and exercised the health endpoint with `python -m api.server --host 127.0.0.1 --port 8765` and `curl http://127.0.0.1:8765/api/health`, which returned `{"ok": true}`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc0c1416a08328a23fa17d3b45ae89)